### PR TITLE
Fixed links to stylesheet and script

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
         <link href="https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,400;0,700;1,400;1,700&family=Press+Start+2P&display=swap" rel="stylesheet">
         <!-- end Google fonts -->
-        <link rel="stylesheet" href="/assets/css/style.css">
+        <link rel="stylesheet" href="assets/css/style.css">
     </head>
     <body>
         <header>
@@ -64,6 +64,6 @@
             </section>
             <!-- END HIDDEN ON START -->
         </main>
-        <script src="/assets/js/script.js"></script>
+        <script src="assets/js/script.js"></script>
     </body>
 </html>


### PR DESCRIPTION
An extra slash before the assets directory was causing the stylesheet and script not to be implemented.